### PR TITLE
Made version of pm2 installed configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ pm2_startup: ubuntu
 pm2_service_enabled: yes
 # current state: started, stopped
 pm2_service_state: started
+# version
+pm2_version: latest
 ```
 
 ## Handlers

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,5 @@ pm2_startup: ubuntu
 pm2_service_enabled: yes
 # current state: started, stopped
 pm2_service_state: started
+# version
+pm2_version: latest

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install packages
-  command: npm install -g pm2 --unsafe-perm
+  command: npm install -g pm2@{{ pm2_version }} --unsafe-perm
   notify: restart pm2
   with_items:
     - pm2


### PR DESCRIPTION
I needed to be able to specify the version of pm2 installed as 0.12.0 wasn't working for me on Amazon Linux when 0.11.0 had been working fine.
