### PR TITLE
Remove the franklinkim.nodejs dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,3 +15,4 @@ galaxy_info:
 # dependencies available via galaxy should be listed here.
 # Be sure to remove the '[]' above if you add dependencies
 # to this list.
+dependencies: []


### PR DESCRIPTION
I install `node` via `nvm`, which would conflict with the version installed by `apt-get`