### PR TITLE
Allow the service name to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Here is a list of all the default variables for this role, which are also availa
 pm2_apps: []
 # startup system
 pm2_startup: ubuntu
+# service name for startup system
+pm2_service_name: pm2-init.sh
 # start on boot
 pm2_service_enabled: yes
 # current state: started, stopped
@@ -71,7 +73,7 @@ These are the handlers that are defined in `handlers/main.yml`.
 ---
 
 - name: restart pm2
-  service: name=pm2-init.sh state=restarted
+  service: name={{ pm2_service_name }} state=restarted
   when: pm2_service_state != 'stopped'
 
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@
 pm2_apps: []
 # startup system
 pm2_startup: ubuntu
+# service name for startup system
+pm2_service_name: pm2-init.sh
 # start on boot
 pm2_service_enabled: yes
 # current state: started, stopped

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 
 - name: restart pm2
-  service: name=pm2-init.sh state=restarted
+  service: name={{ pm2_service_name }} state=restarted
   when: pm2_service_state != 'stopped'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -2,6 +2,6 @@
 
 - name: Configuring service
   service:
-    name: pm2-init.sh
+    name: "{{ pm2_service_name }}"
     state: "{{ pm2_service_state }}"
     enabled: "{{ pm2_service_enabled }}"


### PR DESCRIPTION
Exposes the service name as variable so that pm2 can be started up via systemd using:
```
    pm2_startup: systemd
    pm2_service_name: pm2
```
