### PR TITLE
Add curly braces and quotes

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -11,4 +11,4 @@
   command: "pm2 start {{ item.run }} {{ item.args | default('') }}"
   args:
     chdir: "{{ item.path | default(omit) }}"
-  with_items: pm2_apps
+  with_items: "{{ pm2_apps }}"


### PR DESCRIPTION
Fix for Ansible 2.1 compatibility.

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pm2_apps}}').
This feature will be removed in a future release. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```