### PR TITLE
Force become when installing startup script.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ pm2_service_enabled: yes
 pm2_service_state: started
 # version
 pm2_version:
+# User
+pm2_user: "{{ ansible_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,3 +8,4 @@
 
 - name: Installing startup script
   command: "pm2 startup"
+  become: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,6 +6,12 @@
     global: yes
     version: "{{ pm2_version | default(omit) }}"
 
+- name: Lookup user home
+  shell: >
+    egrep "^{{ pm2_user }}:" /etc/passwd | awk -F: '{ print $6 }'
+  changed_when: false
+  register: user_home
+
 - name: Installing startup script
-  command: "pm2 startup"
+  command: "pm2 startup -u {{ pm2_user }} --hp {{ user_home.stdout }}"
   become: yes

--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -7,6 +7,8 @@
 
 - name: Starting apps
   environment: "{{ item.env | default({}) }}"
+  become_user: "{{ pm2_user }}"
+  become: yes
   shell: "pm2 start {{ item.run }} {{ item.args | default() }}"
   args:
     chdir: "{{ item.path | default(omit) }}"


### PR DESCRIPTION
Hello, 

Maybe this is a Vagrant bug, but I have the following problem: 

When PM2 runs as `root`, changes on files in shared folders are not detected by PM2 when using the `watch` option. When PM2 runs as `vagrant` user, it works. 

So I need to run this role with `become=no`

```
roles:
    - { role: weareinteractive.pm2, become: no }
```

**BUT** if I do that the startup script is not installed correctly because it needs to be run as `root`. 

So I forced `become=yes` for this command. 