### PR TITLE
Consistent commands and application management (same user)

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: Executing commands
+  become_user: "{{ pm2_user }}"
+  become: yes
   environment: "{{ item.env | default(pm2_cmds_default_env) }}"
   shell: "pm2 {{ item.run }} {{ item.args | default() }}"
   register: pm2_cmd_result


### PR DESCRIPTION
When creating apps with pm2_apps var, it is impossible to manage them through commands as the user is not the same (pm2_user)