### PR TITLE
more robust error recognition

### DIFF
--- a/tasks/manage.yml
+++ b/tasks/manage.yml
@@ -20,5 +20,5 @@
   register: pm2_app_result
   args:
     chdir: "{{ item.path | default(omit) }}"
-  failed_when: "'[ERROR]' in pm2_app_result.stderr"
+  failed_when: "pm2_app_result.stderr is defined and pm2_app_result.stderr.find('[ERROR]') != -1"
   with_items: "{{ pm2_apps }}"


### PR DESCRIPTION
When pm2_app_result.stderr contains special characters, the test fails:
fatal: [reverse.inte.fiftytruck.com]: FAILED! => {"failed": true, "msg": "The conditional check 'pm2_app_result.stderr.find('[ERROR]') != -1' failed. The error was: error while evaluating conditional (pm2_app_result.stderr.find('[ERROR]') != -1): 'dict object' has no attribute 'stderr'"}

My proposition is a more robust test to detect when application command failed.