### PR TITLE
Ensures that the update of PM2 occurs right after install

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,7 +5,10 @@
     name: pm2
     global: yes
     version: "{{ pm2_version | default(omit) }}"
-  notify: update pm2
+
+- name: Update to the latest version
+  shell: pm2 updatePM2
+  when: pm2_service_state != 'stopped'
 
 - name: Looking up user home
   shell: >


### PR DESCRIPTION
closes #19 

The issue in #19  is that in Ansible, handlers are called once all the tasks are finished.
But _for some reason_, the update should occur before the service is started.

This PR updates PM2 right after it is installed, by replacing the notification with an explicit task.
The handler is left untouched, as it could be used by other tasks, somewhere.
